### PR TITLE
Proofread blog posts and refresh Yocto doc links

### DIFF
--- a/_posts/2020-03-23-yocto-build-your-own-linux-distro.md
+++ b/_posts/2020-03-23-yocto-build-your-own-linux-distro.md
@@ -229,9 +229,9 @@ builds will be incremental.
 - Never modify another layer (if you want to modify an existing recipe, use a `recipes-something/somelibrary_<VERSION>.bbappend` file in your layer instead)
 
 ## References:
-* [Yocto Project Overview](https://www.yoctoproject.org/docs/latest/overview-manual/overview-manual.html)
-* [Yocto Reference Manual](https://www.yoctoproject.org/docs/latest/ref-manual/ref-manual.html)
-* [BitBake User Manual](https://www.yoctoproject.org/docs/latest/bitbake-user-manual/bitbake-user-manual.html)
+* [Yocto Project Overview](https://docs.yoctoproject.org/overview-manual/index.html)
+* [Yocto Reference Manual](https://docs.yoctoproject.org/ref-manual/index.html)
+* [BitBake User Manual](https://docs.yoctoproject.org/bitbake/index.html)
 
 
 

--- a/_posts/2020-03-23-yocto-build-your-own-linux-distro.md
+++ b/_posts/2020-03-23-yocto-build-your-own-linux-distro.md
@@ -22,9 +22,9 @@ provider for the embedded device we were developing. We wanted to have full cont
 over what software will run on the device and we did not want to deal with external
 distribution support or updates.
 
-While the projects documentation is excellent, the learning curve is quite steep.
-In the begining it can be hard to find a good starting point. So instead of
-wasting any time, let us just jump into creating an own distribution. All you need
+While the project's documentation is excellent, the learning curve is quite steep.
+In the beginning it can be hard to find a good starting point. So instead of
+wasting any time, let us just jump into creating our own distribution. All you need
 is a Debian/Ubuntu host with at least 50 GBytes free disk space.
 
 But be warned. Yocto builds can take a long time when run for the first time.
@@ -45,9 +45,9 @@ bitbake-layers create-layer ../meta-foundation --priority 10
 bitbake-layers add-layer ../meta-foundation
 cd ..
 ```
-As first step we installed the dependencies, created a project directory and cloned
+As a first step we installed the dependencies, created a project directory and cloned
 the poky (Yocto's example linux distribution) into it. We then sourced the yocto
-build environment (which also creates also a build directory with the provided name if it does not exist yet) and created our own layer with the `bitbake-layers` command. 
+build environment (which also creates a build directory with the provided name if it does not exist yet) and created our own layer with the `bitbake-layers` command.
 
 # The project's structure
 
@@ -84,7 +84,7 @@ yocto
     └── scripts
 
 ```
-We have the poky layer which provides us with the build system `bitbake`, a script `oe-init-build-env`to initialze the build environmet and the core layers (all subdirectories starting with `meta`). On the same level we have our newly created meta-foundation layer and the build directory, where all bitbake keeps all the build output and cache as well as some local
+We have the poky layer which provides us with the build system `bitbake`, a script `oe-init-build-env` to initialize the build environment and the core layers (all subdirectories starting with `meta`). On the same level we have our newly created meta-foundation layer and the build directory, where bitbake keeps all the build output and cache as well as some local
 build configuration (e.g. how many threads to use for bitbake and make etc.).
 
 Now let's have a closer look at the structure of our created layer `meta-foundation`:
@@ -132,10 +132,10 @@ python do_build() {
 }
 
 ```
-This only prints something during building. Let us changes this to do
+This only prints something during building. Let us change this to do
 something more meaningful. Often you want to include some library / application
-to your OS. Since `CMake` is quite popular and I often use it for my projects, we
-will add a recipe that builds a cmake project. 
+to your OS. Since CMake is quite popular and I often use it for my projects, we
+will add a recipe that builds a CMake project.
 
 # Add an own recipe
 
@@ -148,7 +148,7 @@ mv recipes-support/example recipes-support/dtr
 mv recipes-support/dtr/example_0.1.bb recipes-support/dtr/dtr_git.bb
 ```
 
-Overwrite our example recipe with one that builds a Cmake based library:
+Overwrite our example recipe with one that builds a CMake-based library:
 ```
 cat > recipes-support/dtr/dtr_git.bb <<'__EOF__'
 SUMMARY = "dtr - C++ utility library"
@@ -201,7 +201,7 @@ __EOF__
 
 A distro can have several images (e.g. base, server, development, production),
 which contain more or less packages.
-So let's add a image that is based on the `core-image-base` and add our recipe
+So let's add an image that is based on the `core-image-base` and add our recipe
 to it.
 ```
 mkdir -p recipes-core/images/
@@ -211,8 +211,8 @@ include recipes-core/images/core-image-base.bb
 IMAGE_INSTALL_append = " dtr-dev"
 __EOF__
 ```
-Sidenote: The package we add is `dtr-dev`, and not `dtr` because it is a header-only library
-and the main package of the cmake based recipe is just the test executable in this
+Sidenote: The package we add is `dtr-dev`, and not `dtr`, because it is a header-only library
+and the main package of the CMake-based recipe is just the test executable in this
 case.
 
 So now we are ready and can finally **bake it**:
@@ -220,7 +220,7 @@ So now we are ready and can finally **bake it**:
 DISTRO=foundation bitbake foundation-image-base
 ```
 
-Great we are building our own linux distribution! Go grab a coffee while the initial
+Great, we are building our own linux distribution! Go grab a coffee — the initial
 build will take a long time, since it builds everything from source. But don't worry, subsequent
 builds will be incremental.
 
@@ -231,7 +231,7 @@ builds will be incremental.
 ## References:
 * [Yocto Project Overview](https://www.yoctoproject.org/docs/latest/overview-manual/overview-manual.html)
 * [Yocto Reference Manual](https://www.yoctoproject.org/docs/latest/ref-manual/ref-manual.html)
-* [Bitbacke User Manual](https://www.yoctoproject.org/docs/latest/bitbake-user-manual/bitbake-user-manual.html)
+* [BitBake User Manual](https://www.yoctoproject.org/docs/latest/bitbake-user-manual/bitbake-user-manual.html)
 
 
 

--- a/_posts/2020-03-30-how-to-organize-your-cpp-project.md
+++ b/_posts/2020-03-30-how-to-organize-your-cpp-project.md
@@ -10,7 +10,7 @@ to organize my projects. Most text books or lectures were more focused on teachi
  either programming principles or language features. So in this post I would like
 to share what is in my opinion the best project structure. 
 
-![Yocto](/assets/images/cpp-logo.svg){: .center-image }
+![C++ logo](/assets/images/cpp-logo.svg){: .center-image }
 
 The answer you usually get when asking how to structure your project is that you
 should look at a well established project / library and stick to something 
@@ -48,7 +48,7 @@ parts in the `include` directory (when you are building only an application you
 basically do not need this directory). Then in the `src` folder you place your
 private headers and the compilation units (aka. `.cpp` files) for your project.
 
-I also usually keep the unit and integration tests of the libray in a separate
+I also usually keep the unit and integration tests of the library in a separate
 `test` folder.
 
 I consider it a good practice to mirror the namespaces of my libraries as

--- a/_posts/2020-04-08-yocto-switch-to-systemd.md
+++ b/_posts/2020-04-08-yocto-switch-to-systemd.md
@@ -4,7 +4,7 @@ title:  "Yocto: Switch to systemd"
 thumbnail: assets/images/systemd-dark.svg
 categories: [embedded, linux, yocto, systemd]
 ---
-Yocto's reference distribution [poky](https://git.yoctoproject.org/cgit/cgit.cgi/poky/tree/meta-poky/README.poky) comes
+Yocto's reference distribution [poky](https://git.yoctoproject.org/poky/tree/meta-poky/README.poky) comes
 with [SysVinit](https://en.wikipedia.org/wiki/Init#SysV-style) as an initialization manager.
 However many major linux distributions use [systemd](https://systemd.io/)
 as a system and service manager. In this post we will look at how to easily switch
@@ -39,5 +39,5 @@ we completely removed all SysVinit dependencies in our image. If you do not spec
 these you can still use SysVinit for your rescue/minimal image.
 
 `DISTRO_FEATURES_BACKFILL_CONSIDERED` lists features which should not be used for
-[feature backfilling](https://www.yoctoproject.org/docs/latest/ref-manual/ref-manual.html#ref-features-backfill).
+[feature backfilling](https://docs.yoctoproject.org/ref-manual/features.html#ref-features-backfill).
 

--- a/_posts/2020-04-08-yocto-switch-to-systemd.md
+++ b/_posts/2020-04-08-yocto-switch-to-systemd.md
@@ -5,14 +5,14 @@ thumbnail: assets/images/systemd-dark.svg
 categories: [embedded, linux, yocto, systemd]
 ---
 Yocto's reference distribution [poky](https://git.yoctoproject.org/cgit/cgit.cgi/poky/tree/meta-poky/README.poky) comes
-with [SysVinit](https://en.wikipedia.org/wiki/Init#SysV-style) as an initalization manager.
+with [SysVinit](https://en.wikipedia.org/wiki/Init#SysV-style) as an initialization manager.
 However many major linux distributions use [systemd](https://systemd.io/)
-as a system and service manager. In this post we will look how to easily switch
+as a system and service manager. In this post we will look at how to easily switch
 your yocto distro to systemd.
 
-![Yocto](/assets/images/systemd-dark.svg){: .center-image }
+![systemd](/assets/images/systemd-dark.svg){: .center-image }
 
-Systemd has been a quite controvorsial replacement for SysVinit and I am not
+Systemd has been a quite controversial replacement for SysVinit and I am not
 going to discuss the pros and cons of them here. This has already been done enough.
 However I am used to systemd from working on Debian, Ubuntu and ArchLinux.
 Therefore I also wanted my distribution to use systemd.
@@ -35,8 +35,8 @@ With `DISTRO_FEATURES_append = " systemd"` and `VIRTUAL-RUNTIME_init_manager = "
 we added systemd and told bitbake to use it as the initialization manager.
 
 With `DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"` and `VIRTUAL-RUNTIME_initscripts = ""`
-we completly removed all SysVinit dependencies in our image. If you do not specify
-these you can still can use SysVinit for your rescue/minimal image.
+we completely removed all SysVinit dependencies in our image. If you do not specify
+these you can still use SysVinit for your rescue/minimal image.
 
 `DISTRO_FEATURES_BACKFILL_CONSIDERED` lists features which should not be used for
 [feature backfilling](https://www.yoctoproject.org/docs/latest/ref-manual/ref-manual.html#ref-features-backfill).

--- a/_posts/2020-04-11-design-patterns-singleton.md
+++ b/_posts/2020-04-11-design-patterns-singleton.md
@@ -23,7 +23,7 @@ can be used to address two categories of design problems.
 The first one is to represent physical objects or resources that are unique in 
 the context of the program. E.g. imagine you are designing software that will
 run on a single car. So a `Car` object might be a singleton, since the software
-will never have to deal with fleet of cars (of course you could also envision a
+will never have to deal with a fleet of cars (of course you could also envision a
 software that controls several cars, where you would not make `Car` a singleton).   
 The second category is objects that are global by design (without representing
 any physical object). E.g. you might decide to implement a resource manager
@@ -37,7 +37,7 @@ So in short. Do not think if you should use a singleton or not, but instead thin
 your design should enforce that a certain object is global and unique.
 
 So if after some consideration you still decided to go ahead with a singleton,
-let's have a look on how to implement one.
+let's have a look at how to implement one.
 
 For the sake of simplicity we will consider the associated data of the singleton
 to be an `int`.
@@ -104,17 +104,17 @@ int value = Singleton::get();
 And thus hopefully a bit more readable and clear.
 
 Now all is fine and well. Everything is static and the singleton is initialized
-before the program i.e. `main()` starts executing and is destroyed after it ends. But
+before the program (i.e. `main()`) starts executing and is destroyed after it ends. But
 what if code in another static object uses our singleton? The order of 
 initialization of static objects is generally undefined (implementation dependent).
 The standard only guarantees that all static objects defined in the same file
-will be initalized in order of their declaration. But as soon as they are spread
+will be initialized in order of their declaration. But as soon as they are spread
 out over several files, we do have a problem. E.g. imagine a singleton logger
-that makes use of singleton memory manager.
-How can we make sure the memory manager is initalized when we use it in the logger
+that makes use of a singleton memory manager.
+How can we make sure the memory manager is initialized when we use it in the logger
 in the static part of our code?
 
-## The Meyers` Singleton
+## The Meyers' Singleton
 Named after [Scott Meyers](https://en.wikipedia.org/wiki/Scott_Meyers), this 
 implementation of a singleton defers its initialization to its first use. Thus
 solving the above mentioned problem of undefined static object initialization
@@ -138,7 +138,7 @@ private:
 The private constructor prevents the program from directly constructing the object.
 Instead the initialization will take place only on the first call of the static
 `instance()` member function. Since this is the only way to access the singleton,
-it is guaranteed to be initialzed on the first usage.
+it is guaranteed to be initialized on the first usage.
 
 The usage would look like this:
 ```cpp
@@ -166,7 +166,7 @@ for (auto i = 0; i < N; ++i) {
 ```
 
 ## The Pimpl Singleton
-Sometimes it is desired to have a clear seperation between interface and
+Sometimes it is desired to have a clear separation between interface and
 implementation. The pointer to implementation (pimpl) idiom exposes only the
 interface in the header file, and the implementation is hidden inside a class
 inside the .cpp file. The actual singleton class then only holds a pointer to 
@@ -207,15 +207,15 @@ avoid the performance overhead mentioned in the previous section.
 (There is also a small overhead of an indirection).
 
 ## How about thread safety?
-Until now we ignored the thread safety of the singletons. But while the here presented
-singleton instances are thread safe, because they are static, the associated data
+Until now we ignored the thread safety of the singletons. But while the singleton
+instances presented here are thread safe, because they are static, the associated data
 members are no different than any other shared variable. When used in a multi-threaded
 context the programmer is responsible to use it in a thread safe manner, e.g.
 protecting them by a mutex.
 
 For a more in-depth view into the subject I highly recommend the book referenced
 below. I hope now you know how to implement your singleton, but remember to think
-twice before deciding to chose a global variable in disguise.
+twice before deciding to choose a global variable in disguise.
 
 ## References 
 * Hands-On Design Patterns with C++ by Fedor G. Pikus (ISBN 978-1-78883-256-4)

--- a/_posts/2020-06-19-basic-inheritance.md
+++ b/_posts/2020-06-19-basic-inheritance.md
@@ -6,39 +6,39 @@ categories: [cpp, design patterns]
 ---
 
 C++ is an object-oriented language and inheritance can be used to define relationships
-between objects in the form of class hierarchies. It provides a mean to structure
+between objects in the form of class hierarchies. It provides a means to structure
 and organize your code. Assuming that you already know the basics of inheritance,
- we will look at how and when to best use it. Especially we look at how to use it 
+we will look at how and when to best use it. In particular, we look at how to use it
 for runtime and compile time polymorphism.
 
 Before you start using inheritance to describe your object's relationships, consider
 also other alternatives. Often composition is a better approach to structure
 your code. A simple guideline is to use composition when the relationship between
-your objects can be described with a `has-a` relationship e.g. the `Robot` class
+your objects can be described with a `has-a` relationship (e.g. the `Robot` class
 has a `Leg`). And use inheritance when it is better described with an `is-a` relationship
 e.g. a `Dog` is an `Animal`. However that does not completely work in some cases. It
 is better to follow the [Liskov Substitution Principle](https://stackoverflow.com/a/584732).
-This principle basically states, that if you chose inheritance, then the `Derived` class should
+This principle basically states, that if you choose inheritance, then the `Derived` class should
 be able to be used anywhere, where the `Base` class is used i.e. you could substitute
 all your `Derived`s with `Base`s.
 
 To give a simple example:
 At first it might seem like a good idea to make your `Penguin` class inherit from
-the `Bird` class because a pengin *is a* bird. However this does not work well in code if
+the `Bird` class because a penguin *is a* bird. However this does not work well in code if
 the `Bird` class has a `fly()` method in its interface. So following Liskov,
 we should not use this inheritance, because we could not use `Penguin` everywhere
 we used `Bird`.
  
 ![Liskov Meme](https://web.archive.org/web/20160505182607/https://lostechies.com/derickbailey/files/2011/03/LiskovSubtitutionPrinciple_52BB5162.jpg){: .center-image }
 
-When is it then a good idea to use inheritance? Often it is to used together
-with virtual functions for runtime polymorphism. 
+When is it then a good idea to use inheritance? Often it is used together
+with virtual functions for runtime polymorphism.
 Following the [don't repeat yourself](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle
 we want to write code that does the same thing for similar objects, but we do not want
 to write the same code for every single class again.
 
 ## Runtime Polymorphism
-So let's assume we have a `PositionSensor` and a `AccelerationSensor` class. However
+So let's assume we have a `PositionSensor` and an `AccelerationSensor` class. However
 our program should detect during runtime how many of each are present and should
 store them in a container. So a possible solution is to introduce a `Sensor` base
 class and use this base class' interface in the part of the code that deals with sensors
@@ -62,22 +62,23 @@ std::vector<std::unique_ptr<Sensor>> detect(Hardware* hw){
   std::vector<std::unique_ptr<Sensor>> sensors;
   for (size_t i = 0; i < hw->num_sensors(); ++i) {
     auto type = hw->get_next_sensor_type();
-    switch (type):
-    case SensorType::Position:
-      sensors.emplace_back(std::make_unique<PositionSensor>());
-      break;
-    case SensorType::Acceleration:
-      sensors.emplace_back(std::make_unique<AccelerationSensor>());
-      break;
-    default:
-      throw std::runtime_error("Sensor type not supported");
+    switch (type) {
+      case SensorType::Position:
+        sensors.emplace_back(std::make_unique<PositionSensor>());
+        break;
+      case SensorType::Acceleration:
+        sensors.emplace_back(std::make_unique<AccelerationSensor>());
+        break;
+      default:
+        throw std::runtime_error("Sensor type not supported");
+    }
   }
   return sensors;
 }
 
 ...
 
-GUI::update_sensor_values(std::vector<std::unique_ptr<Sensor>>& sensors) {
+void GUI::update_sensor_values(std::vector<std::unique_ptr<Sensor>>& sensors) {
   for (size_t i = 0; i < sensors.size(); ++i) {
     display_values_.at(i) = sensors.at(i)->measure_value();
   }
@@ -100,9 +101,9 @@ polymorphism through virtual function calls.
 
 In some cases you want to write generic code, but you already know your polymorphic
 types at compile time and you don't want to pay the runtime cost of virtual
-function calls. One way of achieving this in C++ is called the Curriously Recurring
-Template Pattern (CRTP) idiom. 
-It's main idea is to use the derived class as a template parameter of the base
+function calls. One way of achieving this in C++ is called the Curiously Recurring
+Template Pattern (CRTP) idiom.
+Its main idea is to use the derived class as a template parameter of the base
 class.
 
 ```cpp
@@ -119,8 +120,8 @@ struct Derived : Base<Derived> {
 ```
 If you see this for the first time it might look a bit weird. The `Derived` class
 inherits from the `Base` class with itself as a template parameter. But this way
-we have the possiblity to access the methods of the derived class in the base class.
-And if we name the method of the derived class the same we can overwrite the base
+we have the possibility to access the methods of the derived class in the base class.
+And if we name the method of the derived class the same, we can override the base
 class method.
 But let's just change above example to compile time polymorphism to better see how
 this works:
@@ -145,7 +146,7 @@ struct PositionSensor : Sensor<PositionSensor> {
 ...
 
 template <typename Derived>
-GUI::update_sensor_value(int i, Sensor<Derived>& sensor) {
+void GUI::update_sensor_value(int i, Sensor<Derived>& sensor) {
   display_values_.at(i) = sensor.measure_value();
 }
 
@@ -161,7 +162,7 @@ gui.update_sensor_value(1, sensor1);
 
 ```
 
-Now this example is of course a bit oversimplified and you could achieve the same,
+Now this example is of course a bit oversimplified and you could achieve the same
 with a simple templated `update_sensor_value` function. But as soon as you have more
 logic built into your classes you will see that the CRTP is a good way to write
 generic code for types you already know at compile time.

--- a/_posts/2020-09-02-design-patterns-template-method.md
+++ b/_posts/2020-09-02-design-patterns-template-method.md
@@ -31,9 +31,9 @@ private:
 ```
 
 This is great because the interface `measure()` is separated from the implementation `do_measure()`.
-If we would simply make the `measure()` method virtual and override it in the base class, the
+If we simply made the `measure()` method virtual and overrode it in the derived classes, the
 implementation and interface would be coupled and it would make it harder to maintain such classes.
-If we want later to add some functionality it will be much easier with the template method / a non-virtual
+If we want to add some functionality later it will be much easier with the template method / a non-virtual
 interface. E.g. we want to filter each sensor value.
 Then we can just modify the base class like this:
 ```cpp
@@ -49,14 +49,14 @@ private:
 };
 ```
 The interface `measure()` stays exactly the same and none of the client code has to be modified.
-This would not have been possible, had we worked with a overloading a virtual interface.
+This would not have been possible, had we worked by overriding a virtual interface.
 
 So make your interface non-virtual and public in the base class and separate the implementation into private/protected
 virtual functions which the derived classes can override.
 
 ## References 
 * Hands-On Design Patterns with C++ by Fedor G. Pikus (ISBN 978-1-78883-256-4)
-* [Virtuality - Herb Sutter](http://www.gotw.ca/publications/mill18.htm)
+* [Virtuality - Herb Sutter](https://www.gotw.ca/publications/mill18.htm)
 
 
 

--- a/_posts/2020-10-18-command-pattern.md
+++ b/_posts/2020-10-18-command-pattern.md
@@ -103,9 +103,9 @@ To give a more complete example we will also look at the communication and seria
 
 # Deserialize it!
 
-On the communication interface (which we will define bellow) we will receive the commands in a certain format / protocol and we need
+On the communication interface (which we will define below) we will receive the commands in a certain format / protocol and we need
 to parse these messages into our command representation above. For this example I will use JSON. JSON is in my opinion a very
-good starting point for machine to machine communication, because it is also human readable and hence easy to debug. Most of the time its performance is also good enough for sending small data like the here mentioned commands.
+good starting point for machine to machine communication, because it is also human readable and hence easy to debug. Most of the time its performance is also good enough for sending small data like the commands mentioned here.
 
 I decided to use [nlohmann/json](https://github.com/nlohmann/json) for this example:
 
@@ -163,8 +163,8 @@ Like for the serialization part above, there exist many possibilities how to per
 Here we will be using [boost's websocket](https://www.boost.org/doc/libs/1_70_0/libs/beast/doc/html/beast/using_websocket.html) implementation, which is maybe a bit verbose, but available for almost any decent OS.
 
 At some point we will also need some thread safe mechanism to pass the commands from the communication thread to our main thread.
-For simplicity's sake I will just use a `boost::lockfree::queue`, since anyway we are using boost. A thread safe queue is a great way to deal with communication between threads, because from the point of the main thread there will only be a single source of commands. This makes it easier to test,
-e.g. for unit test you can ignore the communication and just fill the command queue another way.
+For simplicity's sake I will just use a `boost::lockfree::queue`, since we are already using boost. A thread safe queue is a great way to deal with communication between threads, because from the point of view of the main thread there will only be a single source of commands. This makes it easier to test;
+e.g. for unit tests you can ignore the communication and just fill the command queue another way.
 
 ```cpp
 #include <boost/lockfree/queue.hpp>
@@ -177,7 +177,7 @@ using CommandQueue = boost::lockfree::queue<cmd::Command>;
 } // namespace cmd
 ```
 
-Our light bulb application will be a websocket server, where clients can connect to. So we define a listener class, which listens for new connections and starts a new session for each (we will define later what a session does).
+Our light bulb application will be a websocket server to which clients can connect. So we define a listener class, which listens for new connections and starts a new session for each (we will define later what a session does).
 ```cpp
 
 #include "commands.hpp"
@@ -407,4 +407,4 @@ And that's it. From the websocket client we can then send our commands as json s
 Some take away points:
 * `std::variant` and `std::visit` are great alternatives to an inheritance based command design.
 * Separating the communication from the hardware control makes it easy to maintain e.g. replacing the communication interface or protocol.
-* Having a single source of commands (here our command queue) makes it very suitable for testing
+* Having a single source of commands (here our command queue) makes it very suitable for testing.

--- a/_posts/2020-11-11-observer-simple.md
+++ b/_posts/2020-11-11-observer-simple.md
@@ -7,12 +7,12 @@ categories: [cpp, design patterns]
 Another classic Gang of Four Pattern is the 
 [Observer Pattern](https://en.wikipedia.org/wiki/Observer_pattern). In this
 pattern, *observers* want to be notified about state changes of a *subject*.
-In this post we will look how to easily implement this with `std::function`.
+In this post we will look at how to easily implement this with `std::function`.
 
 As before I will stick to a sensor example. Let's assume we have a sensor
 that changes its state in unpredictable intervals and different parts of
-your system need to know about these changes. Of course you could pull
-the sensor state form each part. However this is not very elegant and might
+your system need to know about these changes. Of course you could poll
+the sensor state from each part. However this is not very elegant and might
 lead to several unneeded busy loops.
 In the classic pattern the *subject* would keep a list of the *observers*
 but since C++11 we can register callbacks very easily with `std::function`.
@@ -35,7 +35,7 @@ void attach(std::function<void(int)> callback) {
 }
 
 void measure() {
-  // some complex measurment logic which is waiting for hardware
+  // some complex measurement logic which is waiting for hardware
   // state changes...
   const int new_sensor_state = 42;
   notify(new_sensor_state);
@@ -69,7 +69,7 @@ there is no observer class in this observer pattern.
 But you might have realized that there is one small catch. There is no `detach`
 method. Once we registered an observer with `attach` there is no way to deregister.
 That is due to the fact, that `std::function` is not comparable (or only against `nullptr`).
-In many cases this is fine and you want to observer a state during the whole runtime.
+In many cases this is fine and you want to observe a state during the whole runtime.
 However if you need to be able to unregister there is an easy fix for this.
 
 # Observers with handles
@@ -116,7 +116,7 @@ there is no easy workaround for this. If keeping track of handles is not
 acceptable you might at this point be better off not reinventing the wheel
 and use an existing library e.g.
 [boost::signals2](https://www.boost.org/doc/libs/1_74_0/doc/html/signals2.html#id-1.3.36.3.5)
-or [Qt signals](https://doc.qt.io/qt-5/signalsandslots.html)
+or [Qt signals](https://doc.qt.io/qt-5/signalsandslots.html).
 
 ## References 
 * [Generalizing Observer - Herb Sutter](https://www.drdobbs.com/cpp/generalizing-observer/184403873)

--- a/_posts/2021-03-12-yocto-recipe-flavors.md
+++ b/_posts/2021-03-12-yocto-recipe-flavors.md
@@ -55,4 +55,4 @@ python do_install_class-nativesdk () {
 ```
 
 ## References:
-* [Yocto Reference Manual](https://www.yoctoproject.org/docs/latest/ref-manual/ref-manual.html)
+* [Yocto Reference Manual](https://docs.yoctoproject.org/ref-manual/index.html)

--- a/_posts/2021-03-12-yocto-recipe-flavors.md
+++ b/_posts/2021-03-12-yocto-recipe-flavors.md
@@ -5,7 +5,7 @@ thumbnail: assets/images/yocto-logo-bg-dark.svg
 categories: [embedded, linux, yocto]
 ---
 
-If you have done some Yocto development you might already have encounter them in the wild...
+If you have done some Yocto development you might already have encountered them in the wild...
 `native` and `nativesdk` recipes...
 Recipes cannot only be built for the target, but also for your build host or your SDK host.
 This post gives a short summary about what the different recipe "flavors" are used for
@@ -19,7 +19,7 @@ and how to add them to your recipes.
 1. **foo-native**
 1. **nativesdk-foo**
 
-The most common case is just building you recipe `foo`. This builds the recipe for your target architecture e.g. `aarch64`.
+The most common case is just building your recipe `foo`. This builds the recipe for your target architecture e.g. `aarch64`.
 
 But you also might need to build your recipe in the native flavor i.e. `foo-native`. This builds the recipe such that it can be used on the build host e.g. `x86_64`.
 Why would you need that? Let's say you want to build a recipe that, as part of its build, needs to generate some code. This code is generated with python.
@@ -30,7 +30,7 @@ Assume you want to build the same project mentioned above, but this time not wit
 Hence we need to add `nativesdk-python` to our SDK.
 
 # Add native and nativesdk support to your recipes
-Let's start simple: Your recipe is build the same way for all flavors.
+Let's start simple: Your recipe is built the same way for all flavors.
 Then it is enough to just add
 ```
 BBCLASSEXTEND = "native nativesdk"

--- a/_posts/2021-03-17-yocto-add-to-sdk.md
+++ b/_posts/2021-03-17-yocto-add-to-sdk.md
@@ -26,4 +26,4 @@ TOOLCHAIN_HOST_TASK += "nativesdk-cmake nativesdk-ninja"
 Happy baking!
 
 ## References:
-* [Yocto Reference Manual](https://www.yoctoproject.org/docs/latest/ref-manual/ref-manual.html)
+* [Yocto Reference Manual](https://docs.yoctoproject.org/ref-manual/index.html)


### PR DESCRIPTION
## Summary

Follow-up to #4. Two commits:

- **`bd25d34`** — Proofread all 10 published posts. Fixes typos
  (`begining`, `initalize`, `controvorsial`, `seperation`, `pengin`,
  `Curriously`, `possiblity`, `measurment`, `bellow`, `libray`,
  `Bitbacke`, `Cmake`, `Meyers\``, etc.), grammar/wording issues
  (`a mean`→`a means`, `It's main`→`Its main`, `chose`→`choose`,
  `look how`→`look at how`, `pull`→`poll`, `form`→`from`,
  `is to used`→`is used`, `a AccelerationSensor`→`an`,
  `a image`→`an image`, …), and code correctness in
  `2020-06-19-basic-inheritance.md` (invalid `switch (type):` →
  `switch (type) { … }`, missing `void` return types on two
  `GUI::update_sensor_value(s)` definitions, "overwrite" → "override"
  for virtual dispatch). Also corrects two image alt texts that said
  "Yocto" on a C++/systemd logo and upgrades one HTTP link to HTTPS.

- **`9299b02`** — Update Yocto documentation links. The legacy
  `yoctoproject.org/docs/latest/...` URLs and the `cgit/cgit.cgi/poky`
  path no longer resolve cleanly. Point at the current Sphinx-based
  docs at `docs.yoctoproject.org` (Reference Manual, Overview Manual,
  BitBake User Manual, the `features-backfill` anchor) and the modern
  `git.yoctoproject.org/poky/tree/...` URL.

## Test plan

- [x] `bundle exec jekyll build` — clean, no new warnings
- [x] All 10 post permalinks unchanged
- [ ] After merge: spot-check one or two of the new
      `docs.yoctoproject.org` links from a browser


---
_Generated by [Claude Code](https://claude.ai/code/session_01EmacSRk4tJDWdqnq5jTarT)_