### PR TITLE
Bump mobile font size for readability

### DIFF
--- a/_sass/dtrussel-midnight.scss
+++ b/_sass/dtrussel-midnight.scss
@@ -338,6 +338,18 @@ section {
 
 @media print, screen and (max-width: 720px) {
 
+  body {
+    font-size: 16px;
+  }
+
+  code {
+    font-size: 14px;
+  }
+
+  pre code {
+    font-size: 14px;
+  }
+
   #title {
     .credits {
       display: block;


### PR DESCRIPTION
## Summary

Bump body text on screens ≤720px from 14px → 16px, and inline / code-block text from 13px → 14px. Default desktop sizes are unchanged.

## Test plan

- [x] `bundle exec jekyll build` clean
- [ ] Spot-check homepage and a post on mobile / narrow window after merge


---
_Generated by [Claude Code](https://claude.ai/code/session_01EmacSRk4tJDWdqnq5jTarT)_